### PR TITLE
Erro em soup.find()

### DIFF
--- a/web_scra.py
+++ b/web_scra.py
@@ -16,5 +16,5 @@ URL2 = "https://www.washingtonpost.com/technology/2020/09/25/privacy-check-black
 
 soup = BeautifulSoup(pagina.content, "html.parser")
 
-resultado = soup.find_all("div",class_="subtitle is-3")
+resultado = soup.find("h1",class_="title is-1")
 print(resultado.prettify())


### PR DESCRIPTION
Erro estava na procura do find() (primeiro elemento), onde estava procurando por uma tag "div" onde deveria procurar uma tag "h1". 
Também o uso de find_all() não é mais necessário.